### PR TITLE
Alternate Model Architectures

### DIFF
--- a/psat_ml/PSAT-D.py
+++ b/psat_ml/PSAT-D.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun 27 09:01:53 2024
+
+@author: joshuaweston
+"""
+from keras.utils import np_utils
+from keras.models import Sequential
+from keras.layers import Dense, Dropout, Conv2D, MaxPooling2D, Flatten
+from keras.callbacks import ModelCheckpoint  
+
+
+def create_model(num_classes, image_dim):
+    model = Sequential()
+    model.add(Conv2D(filters=16, kernel_size=2, padding='same', \
+                     activation='relu', input_shape=(image_dim, image_dim, 1)))
+    model.add(MaxPooling2D(pool_size=2))
+    model.add(Conv2D(filters=32, kernel_size=2, padding='same', activation='relu'))
+    model.add(MaxPooling2D(pool_size=2))
+    model.add(Conv2D(filters=64, kernel_size=2, padding='same', activation='relu'))
+    model.add(MaxPooling2D(pool_size=2))
+    model.add(Dropout(0.3))
+    model.add(Flatten())
+    model.add(Dense(500, activation='relu'))
+    model.add(Dropout(0.4))
+    model.add(Dense(num_classes, activation='softmax'))
+    model.compile(loss='categorical_crossentropy', optimizer='adam', \
+                  kerasmetrics=['accuracy'])
+    return model


### PR DESCRIPTION
Updated kerasTensorflowClassifier.py to import model architectures rather than have them saved in the file - should make 'plug and playing' of different model architectures a bit easier to track.

New usage: 

  %s <trainingset> [--classifierfile=<classifierfile>] [--trainer=<trainer>] [--outputcsv=<outputcsv>]
  %s (-h | --help)
  %s --version

In the example of the default architecture currently implemented in ATLAS/Pan-STARRs:

Python kerasTensorflowClassifier.py ps2_good44880_bad134640_20240625.h5 --classifierfile=classifier.h5 --trainer=PSAT-D --outputcsv=output.csv

Where PSAT-D.py is a new file in the psat_ml folder containing the model architecture. 